### PR TITLE
Make the taggers option work the same as in Rails::Rack::Logger

### DIFF
--- a/lib/silencer/logger.rb
+++ b/lib/silencer/logger.rb
@@ -5,8 +5,8 @@ module Silencer
   class Logger < Rails::Rack::Logger
     def initialize(app, *taggers)
       @app = app
-      @taggers = taggers
-      opts = @taggers.extract_options!
+      opts = taggers.extract_options!
+      @taggers = taggers.flatten
       @silence = Array.wrap(opts[:silence])
     end
 


### PR DESCRIPTION
`Silencer::Logger#initialize` was changed by #4 to allow an array of taggers to be passed in. Unfortunately, because of the `*taggers`, if you pass in an array of taggers, `@taggers` is incorrectly set to an array _containing_ that array instead of being set to the actual array you passed in.

So when I followed the Readme and swapped out Loggers like this:

``` ruby
config.middleware.swap Rails::Rack::Logger, Silencer::Logger,
  config.log_tags, silence: [%r{^/assets/}]
```

(with `config.log_tags = [:uuid, :remote_ip]`)

The `taggers` arg came in as `[[:uuid, :remote_ip], {:silence=>[/^\/assets\//]}]`, which caused `@taggers` to be set to `[[:uuid, :remote_ip]]` instead of `[:uuid, :remote_ip]`, as intended.

As a result, I was seeing lines in my log file that looked like this:

```
[uuid] [remote_ip]  ........
```

instead of the expected output, which is like this:

```
[4c61461b37360e1f95a00cb8e66d94d7] [127.0.0.1] .......
```

The tests imply that tags should be passed in like this:

``` ruby
    Silencer::Logger.new(@app, :uuid, :queue, :silence => ['/']).call(Rack::MockRequest.env_for("/"))
```

(the example would have needed an extra splat: `config.middleware.swap ..., *config.log_tags, ...`)

However, that contradicts the example in the Readme as well as the method signature of `Rails::Rack::Logger#silence`:

```
      def initialize(app, taggers = nil)
        @app, @taggers = app, taggers || []
      end
```

This patch changes the tests to use the correct API and changes the API to allow it.
