### PR TITLE
add support for silencing specific request methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,27 @@ Or if you'd prefer, you can pass it regular expressions:
 
     config.middleware.swap Rails::Rack::Logger, Silencer::Logger, :silence => [%r{^/assets/}]
 
+Or you can silence specific request methods only:
+
+
+    config.middleware.swap Rails::Rack::Logger, Silencer::Logger, :get => [%r{^/assets/}], :post => [%r{^/some_path}]
+
 Silencer's logger will serve as a drop-in replacement for Rails' default logger.  It will not suppress any logging by default, simply pass it an array of urls via the options hash.  You can also send it a 'X-SILENCE-LOGGER' header (with any value) with your request and that will also produce the same behavior.
+
+### All options
+
+Silencer supports the following configuration options.
+
+    :silence - Silences matching requests regardless of request method
+    :get     - Silences matching GET requests
+    :head    - Silences matching HEAD requests
+    :post    - Silences matching POST requests
+    :put     - Silences matching PUT requests
+    :delete  - Silences matching DELETE requests
+    :patch   - Silences matching PATCH requests
+    :trace   - Silences matching TRACE requests
+    :connect - Silences matching CONNECT requests
+    :options - Silences matching OPTIONS requests
 
 ### Rails 2.3
 

--- a/lib/silencer/hush.rb
+++ b/lib/silencer/hush.rb
@@ -12,7 +12,7 @@ module Silencer
     end
 
     def silent_path?(env)
-      @silence.any? { |s| s === env['PATH_INFO'] }
+      (@routes[env['REQUEST_METHOD']] || @silence).any? { |s| s === env['PATH_INFO'] }
     end
 
   end

--- a/lib/silencer/rack/logger.rb
+++ b/lib/silencer/rack/logger.rb
@@ -11,6 +11,17 @@ module Silencer
       def initialize(app, *args)
         opts     = extract_options!(args)
         @silence = wrap(opts.delete(:silence))
+        @routes  = {
+          'OPTIONS' => wrap(opts.delete(:options)) + @silence,
+          'GET'     => wrap(opts.delete(:get)) + @silence,
+          'HEAD'    => wrap(opts.delete(:head)) + @silence,
+          'POST'    => wrap(opts.delete(:post)) + @silence,
+          'PUT'     => wrap(opts.delete(:put)) + @silence,
+          'DELETE'  => wrap(opts.delete(:delete)) + @silence,
+          'TRACE'   => wrap(opts.delete(:trace)) + @silence,
+          'CONNECT' => wrap(opts.delete(:connect)) + @silence,
+          'PATCH'   => wrap(opts.delete(:patch)) + @silence,
+        }
 
         super app, *args
       end

--- a/lib/silencer/rails/logger.rb
+++ b/lib/silencer/rails/logger.rb
@@ -15,6 +15,17 @@ module Silencer
       def initialize(app, *args)
         opts     = extract_options!(args)
         @silence = wrap(opts.delete(:silence))
+        @routes  = {
+          'OPTIONS' => wrap(opts.delete(:options)) + @silence,
+          'GET'     => wrap(opts.delete(:get)) + @silence,
+          'HEAD'    => wrap(opts.delete(:head)) + @silence,
+          'POST'    => wrap(opts.delete(:post)) + @silence,
+          'PUT'     => wrap(opts.delete(:put)) + @silence,
+          'DELETE'  => wrap(opts.delete(:delete)) + @silence,
+          'TRACE'   => wrap(opts.delete(:trace)) + @silence,
+          'CONNECT' => wrap(opts.delete(:connect)) + @silence,
+          'PATCH'   => wrap(opts.delete(:patch)) + @silence,
+        }
 
         if normalized_args = normalize(args.flatten)
           super(app, normalized_args)

--- a/spec/silencer/rails/logger_spec.rb
+++ b/spec/silencer/rails/logger_spec.rb
@@ -20,6 +20,40 @@ describe Silencer::Rails::Logger do
       call(Rack::MockRequest.env_for("/assets/application.css"))
   end
 
+  %w(OPTIONS GET HEAD POST PUT DELETE TRACE CONNECT PATCH).each do |method|
+    it "quiets the log when configured with a silenced path for #{method} requests" do
+      expect(::Rails.logger).to receive(:level=).
+        with(::Logger::ERROR).at_least(:once)
+
+      Silencer::Rails::Logger.new(app, method.downcase.to_sym => ['/']).
+        call(Rack::MockRequest.env_for("/", :method => method))
+    end
+
+    it "quiets the log when configured with a regex for #{method} requests" do
+      expect(::Rails.logger).to receive(:level=).
+        with(::Logger::ERROR).at_least(:once)
+
+      Silencer::Rails::Logger.new(app, method.downcase.to_sym => [/assets/]).
+        call(Rack::MockRequest.env_for("/assets/application.css", :method => method))
+    end
+  end
+
+  it 'quiets the log when configured with a silenced path for non-standard requests' do
+    expect(::Rails.logger).to receive(:level=).
+      with(::Logger::ERROR).at_least(:once)
+
+    Silencer::Rails::Logger.new(app, :silence => ['/']).
+      call(Rack::MockRequest.env_for("/", :method => 'UPDATE'))
+  end
+
+  it 'quiets the log when configured with a regex for non-standard requests' do
+    expect(::Rails.logger).to receive(:level=).
+      with(::Logger::ERROR).at_least(:once)
+
+    Silencer::Rails::Logger.new(app, :silence => [/assets/]).
+      call(Rack::MockRequest.env_for("/assets/application.css", :method => 'UPDATE'))
+  end
+
   it 'quiets the log when passed a custom header "X-SILENCE-LOGGER"' do
     expect(::Rails.logger).to receive(:level=).
       with(::Logger::ERROR).at_least(:once)


### PR DESCRIPTION
This adds support for silencing requests for specific request methods. For example, say you have a restful resource where the show action is polled repeatedly by clients. You probably don't care about all those polling requests but would like to see any POSTs made to the same resource. This allows you to specify something like `:get => [%r{^/api/messages}]` which will ignore the requests to get messages, but would still log the requests that create messages.

Backwards compatibility is maintained for anyone currently using the `:silence` option (use the silence option if you don't care about the request method) and requests with the `HTTP_X_SILENCE_LOGGER` will also still be silenced.

I ran the tests using ruby 1.9.3-p484 and 2.0.0-p353 on rails versions 3.0.20, 3.1.12, 3.2.16, 4.0.0, and 4.0.2.
