### PR TITLE
make tagged logging work

### DIFF
--- a/lib/silencer/rails/logger.rb
+++ b/lib/silencer/rails/logger.rb
@@ -27,11 +27,7 @@ module Silencer
           'PATCH'   => wrap(opts.delete(:patch)) + @silence,
         }
 
-        if normalized_args = normalize(args.flatten)
-          super(app, normalized_args)
-        else
-          super(app)
-        end
+        super app, *args
       end
 
       def call(env)

--- a/spec/silencer/rails/logger_spec.rb
+++ b/spec/silencer/rails/logger_spec.rb
@@ -77,12 +77,4 @@ describe Silencer::Rails::Logger do
       call(Rack::MockRequest.env_for("/"))
   end if Silencer::Environment.tagged_logger?
 
-  it 'instantiates with an optional taggers array passed as args' do
-    expect(::Rails.logger).to receive(:level=).
-      with(::Logger::ERROR).at_least(:once)
-
-    Silencer::Rails::Logger.new(app, :uuid, :queue, :silence => ['/']).
-      call(Rack::MockRequest.env_for("/"))
-  end if Silencer::Environment.tagged_logger?
-
 end


### PR DESCRIPTION
Fix #11 - removes initialization option using a flat list, but that doesn't work with the rails logger which expect an array.