### PR TITLE
Make threadsafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Silencer is a simple rack-middleware for Rails that can selectively disable logging on per-action basis.  It's based on a [blog post](http://dennisreimann.de/blog/silencing-the-rails-log-on-a-per-action-basis/) by Dennis Reimann.
 
-__Note__: Silencer is not thread safe.
+__Note__: Silencer is only threadsafe in Rails version 4.2.6 and later.
 
 ## Installation
 

--- a/lib/silencer/rails/logger.rb
+++ b/lib/silencer/rails/logger.rb
@@ -35,13 +35,13 @@ module Silencer
       end
 
       def call(env)
-        old_logger_level     = ::Rails.logger.level
-        ::Rails.logger.level = ::Logger::ERROR if silence_request?(env)
-
-        super
-      ensure
-        # Return back to previous logging level
-        ::Rails.logger.level = old_logger_level
+        if silence_request?(env)
+          ::Rails.logger.silence do
+            super
+          end
+        else
+          super
+        end
       end
 
       private

--- a/lib/silencer/rails/logger.rb
+++ b/lib/silencer/rails/logger.rb
@@ -45,15 +45,12 @@ module Silencer
       end
 
       private
+
       def quiet(&block)
         if ::Rails.logger.respond_to?(:silence)
-          quiet_with_silence do
-            block.call
-          end
+          quiet_with_silence(&block)
         else
-          quiet_with_log_level do
-            block.call
-          end
+          quiet_with_log_level(&block)
         end
       end
 
@@ -68,6 +65,7 @@ module Silencer
       def quiet_with_log_level(&block)
         old_logger_level     = ::Rails.logger.level
         ::Rails.logger.level = ::Logger::ERROR
+
         block.call
       ensure
         # Return back to previous logging level

--- a/spec/silencer/rails/logger_spec.rb
+++ b/spec/silencer/rails/logger_spec.rb
@@ -4,85 +4,77 @@ describe Silencer::Rails::Logger do
   let(:app)       { lambda { |env| [200, {}, ''] } }
   let(:log_tags)  { [:uuid, :queue] }
 
-  it 'quiets the log when configured with a silenced path' do
-    expect(::Rails.logger).to receive(:silence).
-      at_least(:once).and_call_original
-
-    Silencer::Rails::Logger.new(app, :silence => ['/']).
-      call(Rack::MockRequest.env_for("/"))
-  end
-
-  it 'quiets the log when configured with a regex' do
-    expect(::Rails.logger).to receive(:silence).
-      at_least(:once).and_call_original
-
-    Silencer::Rails::Logger.new(app, :silence => [/assets/]).
-      call(Rack::MockRequest.env_for("/assets/application.css"))
-  end
-
-  %w(OPTIONS GET HEAD POST PUT DELETE TRACE CONNECT PATCH).each do |method|
-    it "quiets the log when configured with a silenced path for #{method} requests" do
-      expect(::Rails.logger).to receive(:silence).
-        at_least(:once).and_call_original
-
-      Silencer::Rails::Logger.new(app, method.downcase.to_sym => ['/']).
-        call(Rack::MockRequest.env_for("/", :method => method))
+  context "quieted" do
+    before do
+      expect_any_instance_of(Silencer::Rails::Logger).to receive(:quiet).at_least(:once).and_call_original
     end
 
-    it "quiets the log when configured with a regex for #{method} requests" do
-      expect(::Rails.logger).to receive(:silence).
-        at_least(:once).and_call_original
-
-      Silencer::Rails::Logger.new(app, method.downcase.to_sym => [/assets/]).
-        call(Rack::MockRequest.env_for("/assets/application.css", :method => method))
+    it 'quiets the log when configured with a silenced path' do
+      Silencer::Rails::Logger.new(app, :silence => ['/']).
+        call(Rack::MockRequest.env_for("/"))
     end
+
+    it 'quiets the log when configured with a regex' do
+      Silencer::Rails::Logger.new(app, :silence => [/assets/]).
+        call(Rack::MockRequest.env_for("/assets/application.css"))
+    end
+
+    %w(OPTIONS GET HEAD POST PUT DELETE TRACE CONNECT PATCH).each do |method|
+      it "quiets the log when configured with a silenced path for #{method} requests" do
+        Silencer::Rails::Logger.new(app, method.downcase.to_sym => ['/']).
+          call(Rack::MockRequest.env_for("/", :method => method))
+      end
+
+      it "quiets the log when configured with a regex for #{method} requests" do
+        Silencer::Rails::Logger.new(app, method.downcase.to_sym => [/assets/]).
+          call(Rack::MockRequest.env_for("/assets/application.css", :method => method))
+      end
+    end
+
+    it 'quiets the log when configured with a silenced path for non-standard requests' do
+      Silencer::Rails::Logger.new(app, :silence => ['/']).
+        call(Rack::MockRequest.env_for("/", :method => 'UPDATE'))
+    end
+
+    it 'quiets the log when configured with a regex for non-standard requests' do
+      Silencer::Rails::Logger.new(app, :silence => [/assets/]).
+        call(Rack::MockRequest.env_for("/assets/application.css", :method => 'UPDATE'))
+    end
+
+    it 'quiets the log when passed a custom header "X-SILENCE-LOGGER"' do
+      Silencer::Rails::Logger.new(app).
+        call(Rack::MockRequest.env_for("/", 'HTTP_X_SILENCE_LOGGER' => 'true'))
+    end
+
+    it 'does not tamper with the response' do
+      response = Silencer::Rails::Logger.new(app).
+        call(Rack::MockRequest.env_for("/", 'HTTP_X_SILENCE_LOGGER' => 'true'))
+
+      expect(response[0]).to eq(200)
+    end
+
+    it 'instantiates with an optional taggers array' do
+      Silencer::Rails::Logger.new(app, log_tags, :silence => ['/']).
+        call(Rack::MockRequest.env_for("/"))
+    end if Silencer::Environment.tagged_logger?
+
+    it 'instantiates with an optional taggers array passed as args' do
+      Silencer::Rails::Logger.new(app, :uuid, :queue, :silence => ['/']).
+        call(Rack::MockRequest.env_for("/"))
+    end if Silencer::Environment.tagged_logger?
   end
 
-  it 'quiets the log when configured with a silenced path for non-standard requests' do
-    expect(::Rails.logger).to receive(:silence).
-      at_least(:once).and_call_original
+  it "silences" do
+    logger = Silencer::Rails::Logger.new(app, :silence => ['/'])
 
-    Silencer::Rails::Logger.new(app, :silence => ['/']).
-      call(Rack::MockRequest.env_for("/", :method => 'UPDATE'))
+    if ::Rails.logger.respond_to?(:silence)
+      expect(::Rails.logger).to receive(:silence).at_least(:once)
+    else
+      expect(::Rails.logger).to receive(:level=).
+        with(::Logger::ERROR).at_least(:once)
+    end
+
+    logger.call(Rack::MockRequest.env_for("/"))
+
   end
-
-  it 'quiets the log when configured with a regex for non-standard requests' do
-    expect(::Rails.logger).to receive(:silence).
-      at_least(:once).and_call_original
-
-    Silencer::Rails::Logger.new(app, :silence => [/assets/]).
-      call(Rack::MockRequest.env_for("/assets/application.css", :method => 'UPDATE'))
-  end
-
-  it 'quiets the log when passed a custom header "X-SILENCE-LOGGER"' do
-    expect(::Rails.logger).to receive(:silence).
-      at_least(:once).and_call_original
-
-    Silencer::Rails::Logger.new(app).
-      call(Rack::MockRequest.env_for("/", 'HTTP_X_SILENCE_LOGGER' => 'true'))
-  end
-
-  it 'does not tamper with the response' do
-    response = Silencer::Rails::Logger.new(app).
-      call(Rack::MockRequest.env_for("/", 'HTTP_X_SILENCE_LOGGER' => 'true'))
-
-    expect(response[0]).to eq(200)
-  end
-
-  it 'instantiates with an optional taggers array' do
-    expect(::Rails.logger).to receive(:silence).
-      at_least(:once).and_call_original
-
-    Silencer::Rails::Logger.new(app, log_tags, :silence => ['/']).
-      call(Rack::MockRequest.env_for("/"))
-  end if Silencer::Environment.tagged_logger?
-
-  it 'instantiates with an optional taggers array passed as args' do
-    expect(::Rails.logger).to receive(:level=).
-      with(::Logger::ERROR).at_least(:once)
-
-    Silencer::Rails::Logger.new(app, :uuid, :queue, :silence => ['/']).
-      call(Rack::MockRequest.env_for("/"))
-  end if Silencer::Environment.tagged_logger?
-
 end

--- a/spec/silencer/rails/logger_spec.rb
+++ b/spec/silencer/rails/logger_spec.rb
@@ -5,16 +5,16 @@ describe Silencer::Rails::Logger do
   let(:log_tags)  { [:uuid, :queue] }
 
   it 'quiets the log when configured with a silenced path' do
-    expect(::Rails.logger).to receive(:level=).
-      with(::Logger::ERROR).at_least(:once)
+    expect(::Rails.logger).to receive(:silence).
+      at_least(:once).and_call_original
 
     Silencer::Rails::Logger.new(app, :silence => ['/']).
       call(Rack::MockRequest.env_for("/"))
   end
 
   it 'quiets the log when configured with a regex' do
-    expect(::Rails.logger).to receive(:level=).
-      with(::Logger::ERROR).at_least(:once)
+    expect(::Rails.logger).to receive(:silence).
+      at_least(:once).and_call_original
 
     Silencer::Rails::Logger.new(app, :silence => [/assets/]).
       call(Rack::MockRequest.env_for("/assets/application.css"))
@@ -22,16 +22,16 @@ describe Silencer::Rails::Logger do
 
   %w(OPTIONS GET HEAD POST PUT DELETE TRACE CONNECT PATCH).each do |method|
     it "quiets the log when configured with a silenced path for #{method} requests" do
-      expect(::Rails.logger).to receive(:level=).
-        with(::Logger::ERROR).at_least(:once)
+      expect(::Rails.logger).to receive(:silence).
+        at_least(:once).and_call_original
 
       Silencer::Rails::Logger.new(app, method.downcase.to_sym => ['/']).
         call(Rack::MockRequest.env_for("/", :method => method))
     end
 
     it "quiets the log when configured with a regex for #{method} requests" do
-      expect(::Rails.logger).to receive(:level=).
-        with(::Logger::ERROR).at_least(:once)
+      expect(::Rails.logger).to receive(:silence).
+        at_least(:once).and_call_original
 
       Silencer::Rails::Logger.new(app, method.downcase.to_sym => [/assets/]).
         call(Rack::MockRequest.env_for("/assets/application.css", :method => method))
@@ -39,24 +39,24 @@ describe Silencer::Rails::Logger do
   end
 
   it 'quiets the log when configured with a silenced path for non-standard requests' do
-    expect(::Rails.logger).to receive(:level=).
-      with(::Logger::ERROR).at_least(:once)
+    expect(::Rails.logger).to receive(:silence).
+      at_least(:once).and_call_original
 
     Silencer::Rails::Logger.new(app, :silence => ['/']).
       call(Rack::MockRequest.env_for("/", :method => 'UPDATE'))
   end
 
   it 'quiets the log when configured with a regex for non-standard requests' do
-    expect(::Rails.logger).to receive(:level=).
-      with(::Logger::ERROR).at_least(:once)
+    expect(::Rails.logger).to receive(:silence).
+      at_least(:once).and_call_original
 
     Silencer::Rails::Logger.new(app, :silence => [/assets/]).
       call(Rack::MockRequest.env_for("/assets/application.css", :method => 'UPDATE'))
   end
 
   it 'quiets the log when passed a custom header "X-SILENCE-LOGGER"' do
-    expect(::Rails.logger).to receive(:level=).
-      with(::Logger::ERROR).at_least(:once)
+    expect(::Rails.logger).to receive(:silence).
+      at_least(:once).and_call_original
 
     Silencer::Rails::Logger.new(app).
       call(Rack::MockRequest.env_for("/", 'HTTP_X_SILENCE_LOGGER' => 'true'))
@@ -70,8 +70,8 @@ describe Silencer::Rails::Logger do
   end
 
   it 'instantiates with an optional taggers array' do
-    expect(::Rails.logger).to receive(:level=).
-      with(::Logger::ERROR).at_least(:once)
+    expect(::Rails.logger).to receive(:silence).
+      at_least(:once).and_call_original
 
     Silencer::Rails::Logger.new(app, log_tags, :silence => ['/']).
       call(Rack::MockRequest.env_for("/"))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,12 +17,12 @@ io = StringIO.new
 
 begin
   require 'rails'
-  ::Rails.logger = ::Logger.new(io)
+  ::Rails.logger = ::ActiveSupport::Logger.new(io)
 rescue LoadError
   require 'activesupport'
   RAILS_ENV            = 'test'
   RAILS_ROOT           = File.dirname(__FILE__)
-  RAILS_DEFAULT_LOGGER = ::Logger.new(io)
+  RAILS_DEFAULT_LOGGER = ::ActiveSupport::Logger.new(io)
   require 'initializer'
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,12 +17,16 @@ io = StringIO.new
 
 begin
   require 'rails'
-  ::Rails.logger = ::ActiveSupport::Logger.new(io)
+  if Rails::VERSION::MAJOR >= 4
+    ::Rails.logger = ::ActiveSupport::Logger.new(io)
+  else
+    ::Rails.logger = ::Logger.new(io)
+  end
 rescue LoadError
   require 'activesupport'
   RAILS_ENV            = 'test'
   RAILS_ROOT           = File.dirname(__FILE__)
-  RAILS_DEFAULT_LOGGER = ::ActiveSupport::Logger.new(io)
+  RAILS_DEFAULT_LOGGER = ::Logger.new(io)
   require 'initializer'
 end
 


### PR DESCRIPTION
In Rails 4.2.6, threadsafe silencing is supported with Rails.logger.silence.  This PR changes from manipulating Rails.logger.level (a global) to using the Rails supported mechanism.