### PR TITLE
Check if Rails Logger Present for environment

### DIFF
--- a/lib/silencer/environment.rb
+++ b/lib/silencer/environment.rb
@@ -6,7 +6,7 @@ module Silencer
     module_function
 
     def rails?
-      defined?(::Rails)
+      defined?(::Rails) && ::Rails.logger.present?
     end
 
     def rails_version


### PR DESCRIPTION
I ran into this when using `activerecord` as a standalone gem (without Rails). This _could_ be a misconfiguration on my part. However, even when checking `::Rails::VERSION::STRING` in a [racksh](https://github.com/sickill/racksh) console session, that was also defined. My guess is ActiveRecord is an extension of rails 🤷‍♀️ Since we really only care about the `Logger`, I figure the double check would resolve and suffice.

- Locally, the tests pass. Doesn't look like Travis is happy though 😞 
  - Attempted to fix the travis configs for installing `bundler` to resolve, but a bit beyond me for the moment.