### PR TITLE
Make X-SILENCE-LOGGER header optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,17 @@ Silencer's logger will serve as a drop-in replacement for Rails' default logger.
 
 Silencer supports the following configuration options.
 
-    :silence - Silences matching requests regardless of request method
-    :get     - Silences matching GET requests
-    :head    - Silences matching HEAD requests
-    :post    - Silences matching POST requests
-    :put     - Silences matching PUT requests
-    :delete  - Silences matching DELETE requests
-    :patch   - Silences matching PATCH requests
-    :trace   - Silences matching TRACE requests
-    :connect - Silences matching CONNECT requests
-    :options - Silences matching OPTIONS requests
+    :silence       - Silences matching requests regardless of request method
+    :get           - Silences matching GET requests
+    :head          - Silences matching HEAD requests
+    :post          - Silences matching POST requests
+    :put           - Silences matching PUT requests
+    :delete        - Silences matching DELETE requests
+    :patch         - Silences matching PATCH requests
+    :trace         - Silences matching TRACE requests
+    :connect       - Silences matching CONNECT requests
+    :options       - Silences matching OPTIONS requests
+    :enable_header - Enable/disable X-SILENCE-LOGGER header support (default: true)
 
 ## Note on Patches/Pull Requests
 

--- a/lib/silencer/hush.rb
+++ b/lib/silencer/hush.rb
@@ -2,8 +2,8 @@ module Silencer
   module Hush
     private
 
-    def silence_request?(env)
-      (silent_header?(env) || silent_path?(env))
+    def silence_request?(env, enable_header: true)
+      ((enable_header && silent_header?(env)) || silent_path?(env))
     end
 
     def silent_header?(env)

--- a/lib/silencer/rack/logger.rb
+++ b/lib/silencer/rack/logger.rb
@@ -15,11 +15,13 @@ module Silencer
         @silence = wrap(opts.delete(:silence))
         @routes  = define_routes(@silence, opts)
 
+        @enable_header = opts.delete(:enable_header) { true }
+
         super(app, *args)
       end
 
       def call(env)
-        if silence_request?(env)
+        if silence_request?(env, enable_header: @enable_header)
           quiet(env) do
             super
           end

--- a/lib/silencer/rails/logger.rb
+++ b/lib/silencer/rails/logger.rb
@@ -15,6 +15,8 @@ module Silencer
         @silence = wrap(opts.delete(:silence))
         @routes  = define_routes(@silence, opts)
 
+        @enable_header = opts.delete(:enable_header) { true }
+
         normalized_args = normalize(args)
         if normalized_args
           super(app, normalized_args)
@@ -24,7 +26,7 @@ module Silencer
       end
 
       def call(env)
-        if silence_request?(env)
+        if silence_request?(env, enable_header: @enable_header)
           quiet do
             super
           end

--- a/spec/silencer/rails/logger_spec.rb
+++ b/spec/silencer/rails/logger_spec.rb
@@ -67,6 +67,22 @@ describe Silencer::Rails::Logger do
     end
   end
 
+  describe 'enable_header option' do
+    it 'does not quiet the log when passed a custom header "X-SILENCE-LOGGER" when enable_header option is false' do
+      expect_any_instance_of(Silencer::Rails::Logger).to_not receive(:quiet)
+
+      Silencer::Rails::Logger.new(app, enable_header: false)
+        .call(Rack::MockRequest.env_for('/', 'HTTP_X_SILENCE_LOGGER' => 'true'))
+    end
+
+    it 'quiets the log when passed a custom header "X-SILENCE-LOGGER" when enable_header option is true' do
+      expect_any_instance_of(Silencer::Rails::Logger).to receive(:quiet).once.and_call_original
+
+      Silencer::Rails::Logger.new(app, enable_header: true)
+        .call(Rack::MockRequest.env_for('/', 'HTTP_X_SILENCE_LOGGER' => 'true'))
+    end
+  end
+
   it 'silences' do
     logger = Silencer::Rails::Logger.new(app, silence: ['/'])
 


### PR DESCRIPTION
This adds a new `enable_header` option that makes the `X-SILENCE-LOGGER` optional. 

Added tests for the Rails logger. The Rack logger tests were too difficult for me to update right now, because they appear to all be false positives, and I ran into issues trying to get them to pass legitimately. 