### PR TITLE
Check for ActionDispatch instead of Rails logger

### DIFF
--- a/lib/silencer/environment.rb
+++ b/lib/silencer/environment.rb
@@ -8,7 +8,7 @@ module Silencer
     module_function
 
     def rails?
-      defined?(::Rails) && ::Rails.logger.present?
+      defined?(::ActionDispatch)
     end
 
     def rails_version


### PR DESCRIPTION
[The usage instructions specify to create an initializer for using the middleware](https://github.com/stve/silencer/tree/v1.1.0#rails), which usually happens before [`Rails.logger` is set](https://github.com/stve/silencer/pull/29). So in most Rails applications, it mistakenly uses `Silencer::Rack::Logger`:

```
Puma caught this error: invalid log level:  (ArgumentError)
/home/jm/.rbenv/versions/3.1.1/lib/ruby/3.1.0/logger.rb:268:in `level='
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rack-2.2.3/lib/rack/logger.rb:14:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/silencer-1.1.0/lib/silencer/rack/logger.rb:31:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/sprockets-rails-3.4.2/lib/sprockets/rails/quiet_assets.rb:13:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/middleware/remote_ip.rb:93:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/request_store-1.5.1/lib/request_store/middleware.rb:19:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/middleware/request_id.rb:26:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rack-2.2.3/lib/rack/runtime.rb:22:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/activesupport-7.0.2.3/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/middleware/server_timing.rb:20:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/middleware/executor.rb:14:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/middleware/static.rb:23:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/actionpack-7.0.2.3/lib/action_dispatch/middleware/host_authorization.rb:137:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rack-mini-profiler-3.0.0/lib/mini_profiler/profiler.rb:393:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-7.0.2.3/lib/rails/engine.rb:530:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puma-5.6.4/lib/puma/configuration.rb:252:in `call'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puma-5.6.4/lib/puma/request.rb:77:in `block in handle_request'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puma-5.6.4/lib/puma/thread_pool.rb:340:in `with_force_shutdown'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puma-5.6.4/lib/puma/request.rb:76:in `handle_request'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puma-5.6.4/lib/puma/server.rb:441:in `process_client'
/home/jm/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puma-5.6.4/lib/puma/thread_pool.rb:147:in `block in spawn_thread'
```

This change checks if `ActionDispatch` has been loaded instead, which should still fix the issue reported in #29 (@smridge I'd love your feedback on this change if you're available :heart:).